### PR TITLE
Fix passthrough status code

### DIFF
--- a/lib/rescue_registry/registry.rb
+++ b/lib/rescue_registry/registry.rb
@@ -47,7 +47,7 @@ module RescueRegistry
       handler_class, handler_options = handler_info
 
       if handler_options[:status] == :passthrough
-        handler_options[:status] = passthrough_status(exception)
+        handler_options = handler_options.merge(status: passthrough_status(exception))
       end
 
       handler_class.new(exception, **handler_options)

--- a/spec/dummy/app/controllers/rescue_controller.rb
+++ b/spec/dummy/app/controllers/rescue_controller.rb
@@ -28,7 +28,7 @@ class RescueController < ApplicationController
   register_exception MetaProcError, meta: -> (e) { { class_name: e.class.name.upcase } }
   register_exception CustomHandlerError, handler: CustomErrorHandler
   register_exception RailsError, status: 403, handler: RescueRegistry::RailsExceptionHandler
-  register_exception ActiveRecord::RecordNotFound, status: :passthrough
+  register_exception ActiveRecord::ActiveRecordError, status: :passthrough
   register_exception OtherGlobalError, status: 401
 
   def index

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -110,6 +110,10 @@ if defined?(Rails)
       make_request("::ActiveRecord::RecordNotFound", :jsonapi)
       expect(response.status).to eq(404)
       expect(JSON.parse(response.body)["errors"][0]["code"]).to eq("not_found")
+
+      make_request("::ActiveRecord::StaleObjectError", :jsonapi)
+      expect(response.status).to eq(409), "has correct status for multiple errors"
+      expect(JSON.parse(response.body)["errors"][0]["code"]).to eq("conflict")
     end
 
     it "falls back to global handler" do


### PR DESCRIPTION
The first passthrough status code would be returned for all requests,
this calculates the correct code for each request.