### PR TITLE
fix handling of invalid format types

### DIFF
--- a/lib/rescue_registry/exceptions_app.rb
+++ b/lib/rescue_registry/exceptions_app.rb
@@ -9,12 +9,7 @@ module RescueRegistry
       exception = request.get_header "action_dispatch.exception"
 
       if RescueRegistry.handles_exception?(exception)
-        begin
-          content_type = request.formats.first
-        rescue Mime::Type::InvalidMimeType
-          content_type = Mime[:text]
-        end
-
+        content_type = request.formats.first || Mime[:text]
         response = RescueRegistry.response_for_public(content_type, exception)
       end
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -170,6 +170,12 @@ if defined?(Rails)
         make_request("CustomStatusError", accept: :json, format: "invalid")
         expect(response.status).to eq(401)
       end
+
+      it "passes unhandled errors to default handler" do
+        make_request("StandardError", accept: :json, format: "invalid")
+        expect(response.status).to eq(500)
+        expect(response.body).to include("We're sorry, but something went wrong (500)"), "has standard Rails error message"
+      end
     end
   end
 end


### PR DESCRIPTION
I ran into an issue where an exception would be thrown if the format type was invalid. This happens to us when automated scanners hit our site with junk values. It doesn't appear that that the current handling of this case works as an exception isn't raised. Instead, I added a default mime type if the format returns a nil value. See the tests for more an example.