### PR TITLE
Support application specific values for error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ class MyController < ActionController::Base
   register_exception MetaProcError, meta: -> (e) { { class_name: e.class.name.upcase } }
   register_exception CustomHandlerError, handler: CustomErrorHandler
   register_exception RailsError, status: 403, handler: RescueRegistry::RailsExceptionHandler
+  register_exception CustomStatusError, status: 422, code: :name_invalid
 end
 ```
 

--- a/lib/rescue_registry/exception_handler.rb
+++ b/lib/rescue_registry/exception_handler.rb
@@ -21,6 +21,7 @@ module RescueRegistry
       end
 
       @meta = options[:meta]
+      @code = options[:code]
 
       # TODO: Warn about unrecognized options
     end
@@ -29,7 +30,7 @@ module RescueRegistry
     alias_method :status_code, :status
 
     def error_code
-      error_code_from_status
+      @code.presence || error_code_from_status
     end
 
     def title

--- a/spec/dummy/app/controllers/rescue_controller.rb
+++ b/spec/dummy/app/controllers/rescue_controller.rb
@@ -1,5 +1,6 @@
 class RescueController < ApplicationController
   class CustomStatusError < StandardError; end
+  class CustomCodeError < StandardError; end
   class CustomTitleError < StandardError; end
   class DetailExceptionError < StandardError; end
   class DetailProcError < StandardError; end
@@ -21,6 +22,7 @@ class RescueController < ApplicationController
   end
 
   register_exception CustomStatusError, status: 401
+  register_exception CustomCodeError, status: 401, code: :invalid_credentials
   register_exception CustomTitleError, title: "My Title"
   register_exception DetailExceptionError, detail: :exception
   register_exception DetailProcError, detail: -> (e) { e.class.name.upcase }

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -20,6 +20,12 @@ if defined?(Rails)
       expect(response.status).to eq(401)
     end
 
+    it "set code in jsonapi error" do
+      make_request("CustomCodeError", accept: :json)
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body).dig("errors", 0, "code")).to eq "invalid_credentials"
+    end
+
     it "uses custom renderer" do
       make_request("CustomStatusError", accept: :json)
       expect(response.status).to eq(401)


### PR DESCRIPTION
Right now the error code is derived from the status code, ie. 422 -> unprocessible_entity. 

According to https://jsonapi.org/format/#errors, it should be possible to provide application specific values. This can now achieved without registering a custom handler. The default behavior does not change.