### PR TITLE
Remove ruby version upper bound

### DIFF
--- a/rescue_registry.gemspec
+++ b/rescue_registry.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "Registry for Rails Exceptions"
   # spec.description = "TODO: Description of RescueRegistry"
   spec.license     = "MIT"
-  spec.required_ruby_version = [">= 2.3", "< 3.1"]
+  spec.required_ruby_version = ">= 2.3"
 
   spec.metadata = {
     "bug_tracker_uri"   => "https://github.com/wagenet/rescue_registry/issues",


### PR DESCRIPTION
Allow usage with ruby `3.1.0` and beyond.